### PR TITLE
fix: check statusCheckRollup.state for pending CI

### DIFF
--- a/bin/gs-stack-status
+++ b/bin/gs-stack-status
@@ -402,6 +402,10 @@ if [[ -n "$repo_owner" && ${#pr_number_to_branch[@]} -gt 0 ]]; then
       (.commits.nodes[0].commit.statusCheckRollup // null) |
       if . == null then "NO_CI"
       else
+        # Capture rollup-level state for cases where checks haven't been
+        # created yet (e.g., queued workflow jobs). The rollup knows CI is
+        # pending even when no individual PENDING check nodes exist.
+        (.state // "UNKNOWN") as $rollup_state |
         (.contexts.nodes // []) as $nodes |
         ($nodes | map(select(. != null))) as $all_valid |
         # Deduplicate: GitHub returns stale check runs from older workflow
@@ -448,7 +452,7 @@ if [[ -n "$repo_owner" && ${#pr_number_to_branch[@]} -gt 0 ]]; then
             .cState != null and (.cState | IN("FAILURE", "ERROR"))
           )) | length) as $sc_failed |
 
-          (($cr_running + $sc_running) > 0) as $any_running |
+          (($cr_running + $sc_running) > 0 or ($rollup_state | IN("PENDING", "EXPECTED"))) as $any_running |
           (($cr_failed + $sc_failed) > 0) as $any_failed |
 
           if $any_running and $any_failed then


### PR DESCRIPTION
## Summary

- Fixes a bug where gs-stack-status shows 🔴 (CI failed) for PRs where CI is still running
- When CI workflow jobs are queued but not yet created, the rollup `state` is `PENDING` but no individual check nodes exist with `PENDING` status, so `$any_running` evaluates false and the script falls through to `CI_FAIL`
- Captures the rollup-level `.state` field and incorporates it into the `$any_running` calculation so `PENDING`/`EXPECTED` rollup states correctly show as 🟡 (running)

## Test plan

- [ ] Push a commit to a PR and immediately run `gs-stack-status` while CI is starting up
- [ ] Verify the PR shows 🟡 instead of 🔴 during the initial CI pending phase
- [ ] Verify that once CI completes, the status correctly shows 🟢 or 🔴

🤖 Generated with [Claude Code](https://claude.com/claude-code)