### PR TITLE
Add mise/ubi support with platform-specific release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,21 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Upload release assets
+        env:
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          TAG="${{ steps.release.outputs.tag }}"
+          # gs-stack-status is a platform-independent bash script, but ubi (used by
+          # mise) expects assets named with OS/arch patterns. Upload copies
+          # for each supported platform so `mise install ubi:nsheaps/gs-stack-status`
+          # works out of the box.
+          for platform in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do
+            cp bin/gs-stack-status "gs-stack-status-${platform}"
+          done
+          gh release upload "$TAG" gs-stack-status-linux-amd64 gs-stack-status-linux-arm64 gs-stack-status-darwin-amd64 gs-stack-status-darwin-arm64
+          rm -f gs-stack-status-linux-amd64 gs-stack-status-linux-arm64 gs-stack-status-darwin-amd64 gs-stack-status-darwin-arm64
+
   update-homebrew:
     needs: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Upload platform-named copies of the bash script (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64) as GitHub release assets so `mise install ubi:nsheaps/gs-stack-status` works

## Test plan
- [ ] Verify release workflow syntax is valid
- [ ] Test that next release uploads platform assets correctly
- [ ] Confirm `mise install ubi:nsheaps/gs-stack-status` works after a release

https://claude.ai/code/session_01UNAUtVFRfFTyfXXLy7dJNz