### PR TITLE
Fix shallow re-checkout dropping tags in release job

### DIFF
--- a/.github/actions/github-app-auth/action.yml
+++ b/.github/actions/github-app-auth/action.yml
@@ -75,3 +75,4 @@ runs:
         token: ${{ steps.app-token.outputs.token }}
         clean: false
         persist-credentials: true
+        fetch-depth: 0


### PR DESCRIPTION
## What was broken

The `release` job in `.github/workflows/release.yaml` failed at `git describe --tags --abbrev=0` with:

```
fatal: No tags can describe 'ed172eea86edb04f6feaddbe4a95eb1bd8f80109'.
Try --always, or create some tags.
```

## Root cause (verified against actual job logs, not the initial diagnosis)

The initial audit diagnosis assumed the top-level `actions/checkout` step in `release.yaml` was shallow. It isn't — I confirmed it already has `fetch-depth: 0` and correctly fetches all tags (visible in the job logs: `[new tag] v0.0.1 -> v0.0.1` ... `v0.3.9`).

The real cause is inside `.github/actions/github-app-auth/action.yml`, which this job calls via `uses: ./.github/actions/github-app-auth`. That composite action has its own "Configure repo checkout token" step that re-runs `actions/checkout` (to swap in the GitHub App token) with **no `fetch-depth` specified**, which defaults to `fetch-depth: 1`. Per the job logs, this second checkout:

- Deletes the existing full-history local `main` branch
- Does a shallow (`--depth=1`) fetch of just the target commit
- Re-checks out `main` from that 1-commit shallow history

This discards the full clone + tags that the outer job's checkout had just fetched. The subsequent "Fetch tags" step (`git fetch --tags --force`) re-fetches tag *refs*, but since the repo is still shallow (1 commit deep), none of those tags are reachable from `HEAD` in the local history — so `git describe --tags` has nothing to walk to and fails with exit 128.

## Fix

Added `fetch-depth: 0` to the "Configure repo checkout token" step in `.github/actions/github-app-auth/action.yml`, matching the outer checkout's setting, so the credential-refresh checkout preserves full history and tags instead of re-shallowing the repo.

## Related

Workflow run: https://github.com/nsheaps/gs-stack-status/actions/runs/31451451529

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVFv5W7PcrwW3oggaBsM3k)_